### PR TITLE
Trainer client show page

### DIFF
--- a/app/controllers/trainer/clients_controller.rb
+++ b/app/controllers/trainer/clients_controller.rb
@@ -1,0 +1,5 @@
+class Trainer::ClientsController < ApplicationController
+  def show
+    @client = Client.find(params[:id])
+  end
+end

--- a/app/controllers/trainer/dashboard_controller.rb
+++ b/app/controllers/trainer/dashboard_controller.rb
@@ -1,0 +1,5 @@
+class Trainer::DashboardController < ApplicationController
+  def show
+    @trainer = current_trainer
+  end
+end

--- a/app/controllers/trainers_controller.rb
+++ b/app/controllers/trainers_controller.rb
@@ -1,5 +1,0 @@
-class TrainersController < ApplicationController
-  def show
-    @trainer = current_trainer
-  end
-end

--- a/app/views/trainer/clients/show.html.erb
+++ b/app/views/trainer/clients/show.html.erb
@@ -1,0 +1,4 @@
+<h1><%= @client.first_name %> <%= @client.last_name %></h1>
+Calories, Carbs, Sugar, etc. Stat Graphs here
+<%= button_to "Change Client's Meal Plan" %>
+<%= button_to "Back To Trainer's Client List", trainer_dashboard_path, method: :get %>

--- a/app/views/trainer/dashboard/show.html.erb
+++ b/app/views/trainer/dashboard/show.html.erb
@@ -1,7 +1,7 @@
 <div id="clients">
   <% @trainer.clients.each do |client| %>
     <div class="client-<%= client.id %>">
-      <%= client.first_name %> <%= client.last_name %><br>
+      <%= button_to "#{client.first_name} #{client.last_name}", trainer_client_path(client.id), method: :get %>
       <%= link_to client.email, client.email %>
     </div><br>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,15 +2,18 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'welcome#index'
   get "/about", to: 'welcome#show', as: "about"
-  
+
   get "logout", to: "sessions#destroy", as: "logout"
   get "login", to: "sessions#new", as: "login"
-  
+
   get "register", to: "users#new", as: "register"
   get "/dashboard", to: "users#show"
-  
-  get '/trainer/dashboard', to: 'trainers#show'
-  
+
+  namespace :trainer do
+    get '/dashboard', to: 'dashboard#show'
+    get '/clients/:id', to: 'clients#show', as: "client"
+  end
+
   resource :meal_logs, only: [:new, :create]
   resource :meal_searches, only: :create
 end

--- a/spec/features/trainers/trainer_can_see_client_show_page_spec.rb
+++ b/spec/features/trainers/trainer_can_see_client_show_page_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+feature 'trainer client show page' do
+  before :each do
+    @trainer = create(:trainer)
+    @client = create(:client, trainer: @trainer)
+  end
+
+  it 'trainer sees single client card' do
+    # As a Trainer
+    allow_any_instance_of(ApplicationController).to receive(:current_trainer).and_return(@trainer)
+    # When I visit "trainer/dashboard"
+    visit 'trainer/dashboard'
+    expect(current_path).to eq('/trainer/dashboard')
+    # And I click on a client's card
+    click_on "#{@client.first_name} #{@client.last_name}"
+    # I am taken to that clients show page - "clients/id"
+    expect(current_path).to eq("/trainer/clients/#{@client.id}")
+
+    expect(page).to have_content("#{@client.first_name} #{@client.last_name}")
+    expect(page).to have_button("Change Client's Meal Plan")
+
+    click_on "Back To Trainer's Client List"
+    expect(current_path).to eq('/trainer/dashboard')
+  end
+end

--- a/spec/features/trainers/trainer_can_see_list_of_clients_spec.rb
+++ b/spec/features/trainers/trainer_can_see_list_of_clients_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-feature 'trainer can see list of clients' do
+feature 'trainer show page' do
   before :each do
     @trainer = create(:trainer)
     @client1 = create(:client, trainer: @trainer)
@@ -8,7 +8,7 @@ feature 'trainer can see list of clients' do
     @client3 = create(:client, trainer: @trainer)
   end
 
-  it 'user logs in and sees list of clients' do
+  it 'trainer logs in and sees list of clients' do
     allow_any_instance_of(ApplicationController).to receive(:current_trainer).and_return(@trainer)
 
     visit '/trainer/dashboard'
@@ -16,17 +16,21 @@ feature 'trainer can see list of clients' do
 
     within('#clients') do
       within(".client-#{@client1.id}") do
-        expect(page).to have_content("#{@client1.first_name} #{@client1.last_name}")
-        expect(page).to have_content("#{@client1.email}")
+        expect(page).to have_button("#{@client1.first_name} #{@client1.last_name}")
+        expect(page).to have_link("#{@client1.email}")
       end
       within(".client-#{@client2.id}") do
-        expect(page).to have_content("#{@client2.first_name} #{@client2.last_name}")
-        expect(page).to have_content("#{@client2.email}")
+        expect(page).to have_button("#{@client2.first_name} #{@client2.last_name}")
+        expect(page).to have_link("#{@client2.email}")
       end
       within(".client-#{@client3.id}") do
-        expect(page).to have_content("#{@client3.first_name} #{@client3.last_name}")
-        expect(page).to have_content("#{@client3.email}")
+        expect(page).to have_button("#{@client3.first_name} #{@client3.last_name}")
+        expect(page).to have_link("#{@client3.email}")
       end
     end
+  end
+
+  xit 'trainer sees an intake goals percentage for the week for each client' do
+    # test
   end
 end


### PR DESCRIPTION
- Added individual _trainer client show_ page
  - client name header
  - future implementation: calorie, sodium, carb, etc. graphs
  - button to change meal plan
  - button to return to client list
- Added button for the client names on _trainer dashboard client list_ that links to individual trainer client show page
- **Controller changes**:
  - Renamed trainers_controller to dashboard_controller and moved into trainer folder
  - Added trainer/clients_controller with show page for individual trainer clients
- Put trainer/dashboard and trainer/clients/:id routes into trainer namespace
